### PR TITLE
remove unavailable msf_updates dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,7 @@
   <depend>std_msgs</depend>
   <depend>tf_conversions</depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>msf_updates</exec_depend>
+  <!-- <exec_depend>msf_updates</exec_depend> -->
   <exec_depend>nodelet</exec_depend>
   <exec_depend>tf</exec_depend>
 


### PR DESCRIPTION
msf_updates does not exist as a package which makes rosdep fail. The package is not needed as far as I can see so I removed it.